### PR TITLE
Fixed a bug with a relative path to the partial template.

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -15,5 +15,5 @@ ActionDispatch::Callbacks.to_prepare do
 end
 
 class RedmineScreenshotPasteHook < Redmine::Hook::ViewListener
-  render_on :view_issues_form_details_bottom, :partial => 'screenshot'
+  render_on :view_issues_form_details_bottom, :partial => 'issues/screenshot'
 end


### PR DESCRIPTION
Problem: When Redmine has a plugin, that provides a hook :view_issues_form_details_bottom in own template, the system looks for a template "plugin_name/screenshot", not a template "issues/screenshot".
