### PR TITLE
fixed: plugin_assets may not been found

### DIFF
--- a/app/views/issues/_screenshot.html.erb
+++ b/app/views/issues/_screenshot.html.erb
@@ -7,7 +7,7 @@
       <% end %>
       <%= l(:label_drag_or_paste_from_clipboard) %></a></small><br />
       <object name="imageuploadapplet" id="imageuploadapplet" type="application/x-java-applet" width="400" height="200" style="display: none;">
-        <param name="codebase" value="/plugin_assets/redmine_screenshot_paste/" />
+        <param name="codebase" value="<%= AssetsHelper.plugin_asset_link('', :plugin => 'redmine_screenshot_paste') %>" />
         <param name="archive"  value="simageuploadapplet.jar" />
         <param name="code"     value="imageuploadapplet.Main" />
       </object>

--- a/init.rb
+++ b/init.rb
@@ -1,4 +1,5 @@
 require 'redmine'
+require 'assets_helper'
 
 Redmine::Plugin.register :redmine_screenshot_paste do
   name 'Screenshot Paste'

--- a/lib/assets_helper.rb
+++ b/lib/assets_helper.rb
@@ -1,0 +1,8 @@
+  module AssetsHelper
+    PLUGIN_NAME = File.expand_path('../../*', __FILE__).match(/.*\/(.*)\/\*$/)[1].to_sym
+
+    def self.plugin_asset_link(asset_name,options={})
+      plugin_name=(options[:plugin] ? options[:plugin] : PLUGIN_NAME)
+      File.join(Redmine::Utils.relative_url_root,'plugin_assets',plugin_name.to_s,asset_name)
+    end
+  end


### PR DESCRIPTION
Replaced relative plugin_assets path by a method as described on http://www.redmine.org/boards/3/topics/31445#Links-and-paths-to-plugin-assets

to fix "imageduploadapplet.Main not found" exception in Redmine 2.3.2 having redmine running under sub uri.
